### PR TITLE
Fixed the variation deletion

### DIFF
--- a/lib/melodica_inventory/melodica_inventory/item_destroy.ex
+++ b/lib/melodica_inventory/melodica_inventory/item_destroy.ex
@@ -5,9 +5,9 @@ defmodule ItemDestroy do
     |> Ecto.Multi.delete(:delete_item, item)
   end
 
-  defp delete_images([]), do: {:ok, true}
+  def delete_images([]), do: {:ok, true}
 
-  defp delete_images(images) do
+  def delete_images(images) do
     images
     |> Enum.map(&(&1.public_id))
     |> Cloudex.delete()

--- a/lib/melodica_inventory/melodica_inventory/variation_destroy.ex
+++ b/lib/melodica_inventory/melodica_inventory/variation_destroy.ex
@@ -1,0 +1,13 @@
+defmodule MelodicaInventory.VariationDestroy do
+  def build_destroy_action(variation) do
+    Ecto.Multi.new
+    |> Ecto.Multi.run(:delete_images, fn _ -> delete_images(variation.items) end)
+    |> Ecto.Multi.delete(:delete_variation, variation)
+  end
+
+  defp delete_images(items) do
+    items
+    |> Enum.flat_map(&(&1.images))
+    |> ItemDestroy.delete_images()
+  end
+end

--- a/lib/melodica_inventory/web/controllers/admin/variation_controller.ex
+++ b/lib/melodica_inventory/web/controllers/admin/variation_controller.ex
@@ -1,6 +1,6 @@
 defmodule MelodicaInventory.Web.Admin.VariationController do
   use MelodicaInventory.Web, :controller
-  alias MelodicaInventory.{Variation}
+  alias MelodicaInventory.{Variation, VariationDestroy}
 
   def edit(conn, %{"id" => id}) do
     variation = Repo.get!(Variation, id)
@@ -45,11 +45,9 @@ defmodule MelodicaInventory.Web.Admin.VariationController do
 
   def delete(conn, %{"id" => id}) do
     variation = Repo.get!(Variation, id)
-    |> Repo.preload(items: [:loans])
+    |> Repo.preload(items: [:loans, :images])
 
-    Ecto.Multi.new
-    |> delete_items(variation.items)
-    |> Ecto.Multi.delete(:delete_variation, variation)
+    VariationDestroy.build_destroy_action(variation)
     |> Repo.transaction
     |> case do
       {:ok, _} ->
@@ -63,10 +61,4 @@ defmodule MelodicaInventory.Web.Admin.VariationController do
     end
   end
 
-  defp delete_items(multi, items) do
-    items
-    |> Enum.reduce(multi, fn item, m ->
-      Ecto.Multi.delete(m, :delete_item, item)
-    end)
-  end
 end

--- a/priv/repo/migrations/20170527133428_make-references-delete-all.exs
+++ b/priv/repo/migrations/20170527133428_make-references-delete-all.exs
@@ -1,0 +1,30 @@
+defmodule :"Elixir.MelodicaInventory.Repo.Migrations.Make-references-delete-all" do
+  use Ecto.Migration
+
+  def change do
+    drop constraint(:loans, :loans_item_id_fkey)
+    alter table(:loans) do
+      modify :item_id, references(:items, on_delete: :delete_all)
+    end
+
+    drop constraint(:item_reservations, :item_reservations_item_id_fkey)
+    alter table(:item_reservations) do
+      modify :item_id, references(:items, on_delete: :delete_all)
+    end
+
+    drop constraint(:attachments, :attachments_item_id_fkey)
+    alter table(:attachments) do
+      modify :item_id, references(:items, on_delete: :delete_all)
+    end
+
+    drop constraint(:images, :images_item_id_fkey)
+    alter table(:images) do
+      modify :item_id, references(:items, on_delete: :delete_all)
+    end
+
+    drop constraint(:items, :items_variation_id_fkey)
+    alter table(:items) do
+      modify :variation_id, references(:variations, on_delete: :delete_all)
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -584,7 +584,7 @@ CREATE UNIQUE INDEX users_email_index ON users USING btree (email);
 --
 
 ALTER TABLE ONLY attachments
-    ADD CONSTRAINT attachments_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id);
+    ADD CONSTRAINT attachments_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE;
 
 
 --
@@ -600,7 +600,7 @@ ALTER TABLE ONLY events
 --
 
 ALTER TABLE ONLY images
-    ADD CONSTRAINT images_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id);
+    ADD CONSTRAINT images_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE;
 
 
 --
@@ -616,7 +616,7 @@ ALTER TABLE ONLY item_reservations
 --
 
 ALTER TABLE ONLY item_reservations
-    ADD CONSTRAINT item_reservations_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id);
+    ADD CONSTRAINT item_reservations_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE;
 
 
 --
@@ -624,7 +624,7 @@ ALTER TABLE ONLY item_reservations
 --
 
 ALTER TABLE ONLY items
-    ADD CONSTRAINT items_variation_id_fkey FOREIGN KEY (variation_id) REFERENCES variations(id);
+    ADD CONSTRAINT items_variation_id_fkey FOREIGN KEY (variation_id) REFERENCES variations(id) ON DELETE CASCADE;
 
 
 --
@@ -632,7 +632,7 @@ ALTER TABLE ONLY items
 --
 
 ALTER TABLE ONLY loans
-    ADD CONSTRAINT loans_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id);
+    ADD CONSTRAINT loans_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE;
 
 
 --
@@ -663,5 +663,5 @@ ALTER TABLE ONLY variations
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO "schema_migrations" (version) VALUES (20161120230958), (20161127095807), (20161127101448), (20161127101945), (20161127102144), (20161225222450), (20161225224044), (20161229165155), (20161229170026), (20161230221240), (20170416213841), (20170417092444), (20170504211926), (20170504215324);
+INSERT INTO "schema_migrations" (version) VALUES (20161120230958), (20161127095807), (20161127101448), (20161127101945), (20161127102144), (20161225222450), (20161225224044), (20161229165155), (20161229170026), (20161230221240), (20170416213841), (20170417092444), (20170504211926), (20170504215324), (20170527133428);
 

--- a/test/melodica_inventory/variation_destroy_test.exs
+++ b/test/melodica_inventory/variation_destroy_test.exs
@@ -1,0 +1,43 @@
+defmodule MelodicaInventory.VariationDestroyTest do
+  use MelodicaInventory.ModelCase
+
+  import Mock
+
+  alias MelodicaInventory.VariationDestroy
+  alias MelodicaInventory.{Variation, Item}
+  import MelodicaInventory.Factory
+
+  test "deleting variaion without items" do
+    variation = insert(:variation)
+    |> Repo.preload([:items])
+
+    variation_destroy = VariationDestroy.build_destroy_action(variation)
+
+    {:ok, _} = Repo.transaction(variation_destroy)
+
+    assert Repo.get(Variation, variation.id) == nil
+  end
+
+  test "deleting variation with items and images" do
+    image = insert(:image)
+    item = Repo.get!(Item, image.item_id)
+    |> Repo.preload([:variation])
+
+    second_item = insert(:item, variation: item.variation)
+
+    variation = Repo.get!(Variation, item.variation_id)
+    |> Repo.preload(items: :images)
+
+    variation_destroy = VariationDestroy.build_destroy_action(variation)
+
+    with_mock Cloudex, [], [delete: fn _ -> [ok: true] end] do
+      {:ok, _} = Repo.transaction(variation_destroy)
+
+      assert Repo.get(Variation, variation.id) == nil
+
+      assert called Cloudex.delete([image.public_id])
+    end
+
+    assert Repo.get(Item, item.id) == nil
+  end
+end


### PR DESCRIPTION
When deleting variations, all cloudex images need to be deleted. Also
the deletes from the variations were not cascading to the related
objects, which was causing referential integrity errors. Added a
migration, which fixes the foreign key constraints.