### PR TITLE
Allow filtering borrowed items

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -76,6 +76,7 @@ h2 {
 }
 
 .loans_list {
+  margin-top: 15px;
   form {
     display: inline-block;
   }

--- a/lib/melodica_inventory/melodica_inventory/item_destroy.ex
+++ b/lib/melodica_inventory/melodica_inventory/item_destroy.ex
@@ -1,4 +1,4 @@
-defmodule ItemDestroy do
+defmodule MelodicaInventory.ItemDestroy do
   def build_item_destroy(item) do
     Ecto.Multi.new
     |> Ecto.Multi.run(:delete_images, fn _ -> delete_images(item.images) end)

--- a/lib/melodica_inventory/melodica_inventory/variation_destroy.ex
+++ b/lib/melodica_inventory/melodica_inventory/variation_destroy.ex
@@ -1,4 +1,6 @@
 defmodule MelodicaInventory.VariationDestroy do
+  alias MelodicaInventory.ItemDestroy
+
   def build_destroy_action(variation) do
     Ecto.Multi.new
     |> Ecto.Multi.run(:delete_images, fn _ -> delete_images(variation.items) end)

--- a/lib/melodica_inventory/web/controllers/admin/item_controller.ex
+++ b/lib/melodica_inventory/web/controllers/admin/item_controller.ex
@@ -1,6 +1,6 @@
 defmodule MelodicaInventory.Web.Admin.ItemController do
   use MelodicaInventory.Web, :controller
-  alias MelodicaInventory.Item
+  alias MelodicaInventory.{Item, ItemDestroy}
 
   def edit(conn, %{"id" => id}) do
     changeset = Repo.get!(Item, id, preload: [:variation])

--- a/lib/melodica_inventory/web/controllers/admin/loan_controller.ex
+++ b/lib/melodica_inventory/web/controllers/admin/loan_controller.ex
@@ -1,11 +1,29 @@
 defmodule MelodicaInventory.Web.Admin.LoanController do
   use MelodicaInventory.Web, :controller
-  alias MelodicaInventory.Loan
+  alias MelodicaInventory.{Loan, User}
 
-  def index(conn, _params) do
+  def index(conn, params) do
+    users = Repo.all(User)
+    |> Enum.map(&({user_name(&1), &1.id}))
+
     loans = (from l in Loan, where: not l.fulfilled)
     |> Repo.all
     |> Repo.preload([:item, :user])
-    render conn, "index.html", loans: loans
+    |> apply_filters(params["filters"])
+
+    render conn, "index.html", loans: loans, users: users
+  end
+
+  defp apply_filters(loans, nil), do: loans
+
+  defp apply_filters(loans, %{"name" => name, "user_id" => user_id}) do
+    loans
+    |> Enum.filter(fn loan ->
+      (name == "" || String.contains?(loan.item.name, name)) && (user_id == "" || loan.user_id == String.to_integer(user_id))
+    end)
+  end
+
+  defp user_name(user) do
+    "#{user.first_name} #{user.last_name}"
   end
 end

--- a/lib/melodica_inventory/web/controllers/admin/loan_controller.ex
+++ b/lib/melodica_inventory/web/controllers/admin/loan_controller.ex
@@ -4,7 +4,7 @@ defmodule MelodicaInventory.Web.Admin.LoanController do
 
   def index(conn, params) do
     users = Repo.all(User)
-    |> Enum.map(&({user_name(&1), &1.id}))
+    |> Enum.map(&user_for_select/1)
 
     loans = (from l in Loan, where: not l.fulfilled)
     |> Repo.all
@@ -23,7 +23,7 @@ defmodule MelodicaInventory.Web.Admin.LoanController do
     end)
   end
 
-  defp user_name(user) do
-    "#{user.first_name} #{user.last_name}"
+  defp user_for_select(user) do
+    {"#{user.first_name} #{user.last_name}", user.id}
   end
 end

--- a/lib/melodica_inventory/web/templates/admin/loan/index.html.eex
+++ b/lib/melodica_inventory/web/templates/admin/loan/index.html.eex
@@ -1,2 +1,12 @@
 <h1>All loans</h1>
+<%= form_for @conn, admin_loan_path(@conn, :index), [as: :filters, method: :get, class: "form-inline"], fn f -> %>
+  <div class="form-group">
+    Filters:
+    <%= text_input f, :name, type: :text, class: "form-control form-control-sm", placeholder: "Item name" %>
+  </div>
+  <div class="form-group">
+    <%= select f, :user_id, @users, prompt: "Agent name" %>
+  </div>
+  <%= submit "Filter", class: "btn btn-sm btn-primary" %>
+<% end %>
 <%= render MelodicaInventory.Web.Admin.LoanView, "_loan_list.html", loans: @loans, conn: @conn %>

--- a/test/controllers/admin/item_controller_test.exs
+++ b/test/controllers/admin/item_controller_test.exs
@@ -3,7 +3,6 @@ defmodule MelodicaInventory.Admin.ItemControllerTest do
 
   import MelodicaInventory.Factory
   import Plug.Test
-  import Mock
 
   alias MelodicaInventory.{Variation, Item}
 
@@ -69,7 +68,7 @@ defmodule MelodicaInventory.Admin.ItemControllerTest do
     end
   end
 
-  def login_user(context) do
+  def login_user(_context) do
     current_user = insert(:user, admin: false)
 
     conn = build_conn()

--- a/test/controllers/admin/loan_controller_test.exs
+++ b/test/controllers/admin/loan_controller_test.exs
@@ -61,7 +61,7 @@ defmodule MelodicaInventory.Admin.LoanControllerTest do
     end
   end
 
-  def login_user(context) do
+  def login_user(_context) do
     current_user = insert(:user, admin: false)
 
     conn = build_conn()

--- a/test/controllers/admin/loan_controller_test.exs
+++ b/test/controllers/admin/loan_controller_test.exs
@@ -1,0 +1,50 @@
+defmodule MelodicaInventory.Admin.LoanControllerTest do
+  use MelodicaInventory.Web.ConnCase, async: false
+
+  import MelodicaInventory.Factory
+  import Plug.Test
+
+  alias MelodicaInventory.Item
+
+  describe "when not authorized" do
+    setup [:login_user]
+
+    test "index redirects to login", %{conn: conn} do
+      response = conn
+      |> get(admin_loan_path(conn, :index))
+
+      assert redirected_to(response) =~ login_path(conn, :index)
+    end
+  end
+
+  describe "when an admin user is authorized" do
+    setup [:login_user, :set_user_as_admin]
+
+    test "index renders all the loans", %{conn: conn} do
+      loan = insert(:loan)
+      item = Repo.get!(Item, loan.item_id)
+
+      response = conn
+      |> get(admin_loan_path(conn, :index))
+
+      assert response.resp_body =~ item.name
+    end
+  end
+
+  def login_user(context) do
+    current_user = insert(:user, admin: false)
+
+    conn = build_conn()
+    |> init_test_session(current_user: current_user.id)
+
+    {:ok, conn: conn, current_user: current_user}
+  end
+
+  def set_user_as_admin(%{current_user: current_user} = context) do
+    current_user = current_user
+    |> change(admin: true)
+    |> Repo.update!
+
+    %{context | current_user: current_user}
+  end
+end

--- a/test/controllers/admin/loan_controller_test.exs
+++ b/test/controllers/admin/loan_controller_test.exs
@@ -29,6 +29,36 @@ defmodule MelodicaInventory.Admin.LoanControllerTest do
 
       assert response.resp_body =~ item.name
     end
+
+    test "index filters the loans by name", %{conn: conn} do
+      loan = insert(:loan)
+      item = Repo.get!(Item, loan.item_id)
+
+      response = conn
+      |> get(admin_loan_path(conn, :index), %{"filters" => %{"name" => item.name, "user_id" => ""}})
+
+      assert response.resp_body =~ item.name
+
+      response = conn
+      |> get(admin_loan_path(conn, :index), %{"filters" => %{"name" => "Random non-existing name", "user_id" => ""}})
+
+      refute response.resp_body =~ item.name
+    end
+
+    test "index filters the loans by user_id", %{conn: conn} do
+      loan = insert(:loan)
+      item = Repo.get!(Item, loan.item_id)
+
+      response = conn
+      |> get(admin_loan_path(conn, :index), %{"filters" => %{"name" => "", "user_id" => Integer.to_string(loan.user_id)}})
+
+      assert response.resp_body =~ item.name
+
+      response = conn
+      |> get(admin_loan_path(conn, :index), %{"filters" => %{"name" => "", "user_id" => "99999"}})
+
+      refute response.resp_body =~ item.name
+    end
   end
 
   def login_user(context) do

--- a/test/controllers/item_controller_test.exs
+++ b/test/controllers/item_controller_test.exs
@@ -87,7 +87,7 @@ defmodule MelodicaInventory.ItemControllerTest do
     end
   end
 
-  def login_user(context) do
+  def login_user(_context) do
     current_user = insert(:user, admin: false)
 
     conn = build_conn()

--- a/test/melodica_inventory/item_destroy_test.exs
+++ b/test/melodica_inventory/item_destroy_test.exs
@@ -3,7 +3,7 @@ defmodule MelodicaInventory.ItemDestroyTest do
 
   import Mock
 
-  alias MelodicaInventory.ItemDestroyTest
+  alias MelodicaInventory.ItemDestroy
   alias MelodicaInventory.Item
   import MelodicaInventory.Factory
 

--- a/test/melodica_inventory/variation_destroy_test.exs
+++ b/test/melodica_inventory/variation_destroy_test.exs
@@ -23,7 +23,7 @@ defmodule MelodicaInventory.VariationDestroyTest do
     item = Repo.get!(Item, image.item_id)
     |> Repo.preload([:variation])
 
-    second_item = insert(:item, variation: item.variation)
+    _second_item = insert(:item, variation: item.variation)
 
     variation = Repo.get!(Variation, item.variation_id)
     |> Repo.preload(items: :images)


### PR DESCRIPTION
Fixes #20 

Added filtering to the loans page, which allows to filter the loans by item name and agent name.

![screenshot 2017-07-28 20 00 14](https://user-images.githubusercontent.com/47639/28727952-65313c56-73cf-11e7-86e5-1942dd74e502.png)
