### PR TITLE
Update Bootstrap to alpha 6

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -6,7 +6,7 @@
     "watch": "brunch watch --stdin"
   },
   "dependencies": {
-    "bootstrap": "4.0.0-alpha.5",
+    "bootstrap": "4.0.0-alpha.6",
     "bootstrap-datepicker": "1.6.4",
     "bootstrap-year-calendar": "1.1.1",
     "font-awesome": "^4.7.0",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -654,12 +654,12 @@ bootstrap-year-calendar@1.1.1:
     bootstrap ">=3.1.1"
     jquery ">=1.8.2"
 
-bootstrap@4.0.0-alpha.5:
-  version "4.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-alpha.5.tgz#a126b648c3bd2f52b8fad4bbc5e2d0ad2abf7064"
+bootstrap@4.0.0-alpha.6:
+  version "4.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-alpha.6.tgz#4f54dd33ac0deac3b28407bc2df7ec608869c9c8"
   dependencies:
-    jquery "1.9.1 - 3"
-    tether "^1.3.7"
+    jquery ">=1.9.1"
+    tether "^1.4.0"
 
 bootstrap@>=3.1.1:
   version "3.3.7"
@@ -1864,9 +1864,13 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-"jquery@1.9.1 - 3", jquery@>=1.7.1, jquery@>=1.8.2:
+jquery@>=1.7.1, jquery@>=1.8.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.1.1.tgz#347c1c21c7e004115e0a4da32cece041fad3c8a3"
+
+jquery@>=1.9.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
 js-base64@^2.1.9:
   version "2.1.9"
@@ -2375,7 +2379,7 @@ pbkdf2@^3.0.3:
     create-hmac "^1.1.2"
 
 "phoenix@file:../deps/phoenix":
-  version "1.3.0-rc.1"
+  version "1.3.0"
 
 "phoenix_html@file:../deps/phoenix_html":
   version "2.9.3"
@@ -2981,7 +2985,7 @@ tar@^2.0.0, tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-tether@^1.3.7:
+tether@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.0.tgz#0f9fa171f75bf58485d8149e94799d7ae74d1c1a"
 

--- a/lib/melodica_inventory_web/templates/layout/app.html.eex
+++ b/lib/melodica_inventory_web/templates/layout/app.html.eex
@@ -12,30 +12,39 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-dark bg-inverse">
-      <ul class="nav navbar-nav">
-        <%= if @current_user do %>
-          <li class="nav-item active"><a class="nav-link" href="/">Categories</a></li>
-          <li class="nav-item active"><a class="nav-link" href="/loans">My loans</a></li>
-          <%= if @current_user.admin do %>
-            <li class="nav-item active"><%= link "All loans", to: admin_loan_path(@conn, :index), class: "nav-link" %></li>
-          <% end %>
-          <li class="nav-item active"><%= link "Events", to: event_path(@conn, :index), class: "nav-link" %></li>
-          <li class="nav-item float-xs-right"><a class="nav-link" href="/auth/logout">Logout <%= @current_user.email %></a></li>
-          <%= if @current_user do %>
-            <%= form_tag current_event_path(@conn, :create), class: "form-inline current_event" %>
-              <select class="form-control-sm mr-sm-2" id="currentEvent" name="current_event_id">
-                <option value="">Select current event</option>
-                <%= for event <- @events do %>
-                  <option value="<%= event.id %>" <%= selected_event_attr(@current_event, event) %>>
-                    <%= event_name(event) %>
-                  </option>
-                <% end %>
-              </select>
-            </form>
-          <% end %>
-        <% end %>
-      </ul>
+    <nav class="navbar navbar-toggleable-md navbar-inverse bg-inverse">
+      <%= if @current_user do %>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
+            <li class="nav-item active"><a class="nav-link" href="/">Categories</a></li>
+            <li class="nav-item"><a class="nav-link" href="/loans">My loans</a></li>
+            <%= if @current_user.admin do %>
+              <li class="nav-item"><%= link "All loans", to: admin_loan_path(@conn, :index), class: "nav-link" %></li>
+            <% end %>
+            <li class="nav-item"><%= link "Events", to: event_path(@conn, :index), class: "nav-link" %></li>
+            <%= if @current_user do %>
+              <%= form_tag current_event_path(@conn, :create), class: "form-inline current_event" %>
+                <select class="form-control-sm mr-sm-2" id="currentEvent" name="current_event_id">
+                  <option value="">Select current event</option>
+                  <%= for event <- @events do %>
+                    <option value="<%= event.id %>" <%= selected_event_attr(@current_event, event) %>>
+                      <%= event_name(event) %>
+                    </option>
+                  <% end %>
+                </select>
+              </form>
+            <% end %>
+          </ul>
+
+          <ul class="navbar-nav ml-auto">
+            <li class="nav-item"><a class="nav-link" href="/auth/logout">Logout <%= @current_user.email %></a></li>
+          </ul>
+        </div>
+      <% end %>
     </nav>
 
     <%= if get_flash(@conn, :info) do %>


### PR DESCRIPTION
#### Related Links
<!-- (place to add related links e.g. Project card) -->
Project card: https://github.com/valo/melodica-inventory/projects/1#card-2901672

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

#### Description
<!-- (A few sentences describing the overall goals of the pull request's commits) -->
Updates Bootstrap to alpha 6 and fixes issues with the navigation bar.
The problem was that in alpha 6 navbar needs the `navbar-toggleable-md`
class. And the log out link needs to be in a separate `ul` in order to be
floated to the right because now the navbar uses flexbox.

Adds a hamburger icon for the collapsed navigation.

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

#### Screenshots
<!-- (if appropriate) -->
![image](https://user-images.githubusercontent.com/5284935/28868491-4adc13d8-7782-11e7-8d79-c1cc90a62806.png)
![image](https://user-images.githubusercontent.com/5284935/28868504-5a500f0e-7782-11e7-9217-d6f9872b42c0.png)
![image](https://user-images.githubusercontent.com/5284935/28868527-698c3d62-7782-11e7-9dcc-c942558cbc63.png)