### PR TITLE
Show the images coming from trello

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -155,14 +155,14 @@ form.link {
 }
 
 #carousel-controls, .image-box img {
-  width: 400px;
-  height: 300px;
+  max-width: 400px;
+  max-height: 300px;
 }
 
 @include media-breakpoint-down(sm) {
   #carousel-controls, .image-box img {
-    width: 240px;
-    height: 180px;
+    max-width: 240px;
+    max-height: 180px;
   }
 
   #carousel-controls .carousel-control-prev {

--- a/lib/melodica_inventory_web/templates/item/show.html.eex
+++ b/lib/melodica_inventory_web/templates/item/show.html.eex
@@ -13,7 +13,7 @@
   <li>Обща бройка: <%= Item.total_quantity(@item) %></li>
   <li>Текущо налични: <%= @item.quantity %></li>
 </ul>
-<%= if length(@item.images) > 0 do %>
+<%= if cover_urls(@item) do %>
   <div class="row">
     <div class="col-10 offset-1 d-flex justify-content-center">
       <div id="carousel-controls" class="carousel slide" data-ride="carousel">

--- a/lib/melodica_inventory_web/views/item_view.ex
+++ b/lib/melodica_inventory_web/views/item_view.ex
@@ -10,7 +10,9 @@ defmodule MelodicaInventoryWeb.ItemView do
   end
 
   def cover_urls(%Item{images: [], attachments: attachments}) do
-    List.first(attachments).url
+    attachments
+    |> Enum.map(&{&1.url, nil})
+    |> Enum.with_index
   end
 
   def cover_urls(%Item{images: images}) do
@@ -20,8 +22,10 @@ defmodule MelodicaInventoryWeb.ItemView do
     |> Enum.with_index
   end
 
-  def cover_url_first_image(%Item{images: []}) do
-    nil
+  def cover_url_first_image(%Item{images: [], attachments: []}), do: nil
+
+  def cover_url_first_image(%Item{images: [], attachments: attachments}) do
+    List.first(attachments).url
   end
 
   def cover_url_first_image(%Item{images: images}) do


### PR DESCRIPTION
We should continue to show the images coming from trello. Also fixed the
width and height of the carousel to use max-width and max-height, so
that we don't break the aspect ration of the images.

